### PR TITLE
Escape non-ASCII symbols correctly

### DIFF
--- a/lib/regex-trie.js
+++ b/lib/regex-trie.js
@@ -1,3 +1,5 @@
+var jsesc = require('jsesc');
+
 /**
  * @module regex-trie
  */
@@ -11,7 +13,7 @@ var RegexTrie = (function () {
      * literal characters; only alphanumeric or underscore ("_") characters are
      * left unescaped.
      *
-     * @class RegexTrie 
+     * @class RegexTrie
      * @constructor
      */
     var RegexTrie = function () {
@@ -30,11 +32,11 @@ var RegexTrie = (function () {
      *
      * Phrases can be added to the trie using `add`. Elements can be wrapped in
      * an array before being added. Only alphanumeric values will be added.
-     * Objects, booleans, arrays, etc will all be ignored (failed attempts to 
+     * Objects, booleans, arrays, etc will all be ignored (failed attempts to
      * add values are silent.)
      *
-     * @method add() 
-     * @param phrase_to_add {array|string|number} 
+     * @method add()
+     * @param phrase_to_add {array|string|number}
      * @chainable
      */
     RegexTrie.prototype.add = function (phrase_to_add) {
@@ -95,7 +97,7 @@ var RegexTrie = (function () {
                     return;
                 }
 
-                walk_result = 
+                walk_result =
                     this._quotemeta(key) + _walk_trie(trie[key], this_arg);
 
                 // When we have more than one key, `insert` references
@@ -115,8 +117,8 @@ var RegexTrie = (function () {
 
     RegexTrie.prototype._to_regex = function (alt_group, char_class, end) {
 
-        var group_has_one_element = function (el) { 
-                return el.length === 1; 
+        var group_has_one_element = function (el) {
+                return el.length === 1;
             },
             result = "";
 
@@ -158,7 +160,7 @@ var RegexTrie = (function () {
 
     RegexTrie.prototype.contains = function (phrase_to_fetch) {
 
-        if ( ! this._is_phrase_valid(phrase_to_fetch) && 
+        if ( ! this._is_phrase_valid(phrase_to_fetch) &&
                 this._num_phrases_in_trie > 0 ) {
             return false;
         }
@@ -202,7 +204,9 @@ var RegexTrie = (function () {
             return phrase;
         }
 
-        return phrase.replace(/([^A-Za-z0-9_])/g, "\\$1");
+        return phrase
+            .replace(/([\t\n\f\r\\\$\(\)\*\+\-\.\?\[\]\^\{\|\}])/g, '\\$1')
+            .replace(/[^\x20-\x7E]/g, jsesc);
     };
 
     return RegexTrie;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,12 @@
       "web": "http://www.handwritten.io"
     }
   ],
-  "dependencies": {},
+  "scripts": {
+    "test": "mocha"
+  },
+  "dependencies": {
+    "jsesc": "^0.5.0"
+  },
   "devDependencies": {
     "mocha": "~1.17.1",
     "should": "~3.1.2",

--- a/test/05_quotemeta.js
+++ b/test/05_quotemeta.js
@@ -5,7 +5,7 @@ var assert    = require('assert'),
 describe('#_quotemeta()', function () {
 
     it('should leave ASCII word-chars unchanged', function () {
-        
+
         var trie   = new RegexTrie(),
             result = trie._quotemeta('foo');
 
@@ -23,7 +23,7 @@ describe('#_quotemeta()', function () {
 
             result = trie._quotemeta(objects[i]);
 
-            if ( typeof result === 'undefined' || 
+            if ( typeof result === 'undefined' ||
                     ( ! result && typeof result !== 'boolean' ) ) {
 
                 should.not.exist(result);
@@ -36,7 +36,7 @@ describe('#_quotemeta()', function () {
     });
 
     it('should escape non letter, phrase, or underscore chars', function () {
-        
+
         var trie   = new RegexTrie(),
             result = trie._quotemeta('^');
 
@@ -44,14 +44,11 @@ describe('#_quotemeta()', function () {
     });
 
     it('should escape non letter, phrase, or underscore chars', function () {
-        
+
         var trie     = new RegexTrie(),
             chars    = '^%$#()[]/.,;|',
             result   = trie._quotemeta(chars),
-            expected = chars
-                .split('')
-                .map( function (chr) { return '\\' + chr; })
-                .join('');
+            expected = "\\^%\\$#\\(\\)\\[\\]/\\.,;\\|";
 
         result.should.eql(expected);
 
@@ -64,7 +61,7 @@ describe('#_quotemeta()', function () {
     });
 
     it('should escape meta chars, leaving non-meta chars alone', function () {
-        
+
         var trie     = new RegexTrie(),
             regex    = trie.regex(),
             chars    = '^foo|bar|farr$',
@@ -81,7 +78,7 @@ describe('#_quotemeta()', function () {
     });
 
     it('should be able to cope with lots of brackets', function () {
-        
+
         var trie     = new RegexTrie(),
             chars    = '[[[[[[[[[[]]]]]]]]]]((()))())(((()))))(()))',
             result   = trie._quotemeta(chars),
@@ -107,6 +104,30 @@ describe('#_quotemeta()', function () {
             chars    = 'foo|bar',
             result   = trie._quotemeta(chars),
             expected = 'foo\\|bar';
+
+        result.should.eql(expected);
+    });
+
+    it('should escape non-ASCII symbols', function () {
+
+        var trie     = new RegexTrie(),
+
+            regex    = trie.regex(),
+            chars    = 'foo\xA9bar',
+            result   = trie._quotemeta(chars),
+            expected = 'foo\\xA9bar';
+
+        result.should.eql(expected);
+    });
+
+    it('should escape astral characters', function () {
+
+        var trie     = new RegexTrie(),
+
+            regex    = trie.regex(),
+            chars    = 'foo\uD834\uDF06bar',
+            result   = trie._quotemeta(chars),
+            expected = 'foo\\uD834\\uDF06bar';
 
         result.should.eql(expected);
     });


### PR DESCRIPTION
Previously, `©` would be escaped as `\©`. With this change all non-ASCII symbols are correctly escaped into an pure ASCII form.
