### PR TITLE
README: Fix incorrect message

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ etc).
         .add(['who', 'what', 'when', 'where'];
 ```
 
-All numbers (except `NaN`) are coerced in to their decimal equivalents before
-being added.
+All numbers (except `NaN`) are coerced into strings before being added.
 
 Before adding new phrases, the trie is checked to see whether or not that
 phrase already exists (using `contains`).


### PR DESCRIPTION
It used to say:

> All numbers (except `NaN`) are coerced in to their decimal equivalents before being added.

This is not true: for example, `999999999999999999999` becomes `"1e+21"` because that’s what it `toString`s to.
